### PR TITLE
Added Navigation Menu for Modify Page

### DIFF
--- a/project/Gui/AdminMainPage.xaml.cs
+++ b/project/Gui/AdminMainPage.xaml.cs
@@ -56,7 +56,7 @@ namespace Project.Gui
                         ContentFrame.Navigate(typeof(AddPage));
                         break;
                     case "Modify":
-                        ContentFrame.Navigate(typeof(ModifyRoomView));
+                        ContentFrame.Navigate(typeof(ModifyPage));
                         break;
                     case "LogOut":
                         var loginPage = new LoginPage();

--- a/project/Gui/ModifyViews/ModifyDepartmentView.xaml
+++ b/project/Gui/ModifyViews/ModifyDepartmentView.xaml
@@ -10,18 +10,20 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Department" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Department" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
 
-            <controls:DataGrid ItemsSource="{Binding Departments}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Departments}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyDoctorView.xaml
+++ b/project/Gui/ModifyViews/ModifyDoctorView.xaml
@@ -11,21 +11,23 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Doctors" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Doctors" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
 
-            <controls:DataGrid ItemsSource="{Binding Doctors}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Doctor ID" Binding="{Binding DoctorID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="User ID" Binding="{Binding UserID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Experience" Binding="{Binding Experience, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="License Number" Binding="{Binding LicenseNumber,UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Doctors}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Doctor ID" Binding="{Binding DoctorID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="User ID" Binding="{Binding UserID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Experience" Binding="{Binding Experience, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="License Number" Binding="{Binding LicenseNumber,UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyDrugView.xaml
+++ b/project/Gui/ModifyViews/ModifyDrugView.xaml
@@ -10,21 +10,21 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Drugs" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
-
-            <controls:DataGrid ItemsSource="{Binding Drugs}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Drug ID" Binding="{Binding DrugID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Administration" Binding="{Binding Administration, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Supply" Binding="{Binding Supply, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Specification" Binding="{Binding Specification, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
-
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Drugs" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
+                <controls:DataGrid ItemsSource="{Binding Drugs}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Drug ID" Binding="{Binding DrugID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Administration" Binding="{Binding Administration, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Supply" Binding="{Binding Supply, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Specification" Binding="{Binding Specification, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyEquipmentView.xaml
+++ b/project/Gui/ModifyViews/ModifyEquipmentView.xaml
@@ -10,21 +10,23 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Equipment" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Equipment" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
 
-            <controls:DataGrid ItemsSource="{Binding Equipments}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Eqipment ID" Binding="{Binding EquipmentID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Specification" Binding="{Binding Specification, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Type" Binding="{Binding Type, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Stock" Binding="{Binding Stock, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Equipments}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Eqipment ID" Binding="{Binding EquipmentID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Name" Binding="{Binding Name, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Specification" Binding="{Binding Specification, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Type" Binding="{Binding Type, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Stock" Binding="{Binding Stock, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyPage.xaml
+++ b/project/Gui/ModifyViews/ModifyPage.xaml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Page
+    x:Class="Project.Gui.ModifyViews.ModifyPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Project.Gui.ModifyViews"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
+    <Grid>
+        <NavigationView PaneDisplayMode="Left" OpenPaneLength="200"
+                SelectionChanged="NavigationView_SelectionChanged" IsSettingsVisible="False" IsBackButtonVisible="Collapsed">
+            <NavigationView.MenuItems>
+                <NavigationViewItem Content="Doctors" Tag="Doctors" />
+                <NavigationViewItem Content="Equipment" Tag="Equipment" />
+                <NavigationViewItem Content="Drugs" Tag="Drugs" />
+                <NavigationViewItem Content="Schedule" Tag="Schedule" />
+                <NavigationViewItem Content="Shifts" Tag="Shifts" />
+                <NavigationViewItem Content="Departments" Tag="Departments" />
+                <NavigationViewItem Content="Rooms" Tag="Rooms" />
+            </NavigationView.MenuItems>
+
+            <Frame x:Name="ModifyPageFrame" Grid.Column="1"/>
+        </NavigationView>
+    </Grid>
+</Page>

--- a/project/Gui/ModifyViews/ModifyPage.xaml.cs
+++ b/project/Gui/ModifyViews/ModifyPage.xaml.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace Project.Gui.ModifyViews
+{
+    /// <summary>
+    /// An empty page that can be used on its own or navigated to within a Frame.
+    /// </summary>
+    public sealed partial class ModifyPage : Page
+    {
+        public ModifyPage()
+        {
+            this.InitializeComponent();
+            ModifyPageFrame.Navigate(typeof(ModifyDoctorView));
+        }
+
+        private void NavigationView_SelectionChanged(NavigationView sender, NavigationViewSelectionChangedEventArgs args)
+        {
+            if (args.SelectedItem is NavigationViewItem selectedItem)
+            {
+                string selectedTag = selectedItem.Tag.ToString();
+
+                if (selectedTag == "Doctors")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyDoctorView));
+                }
+                else if (selectedTag == "Equipment")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyEquipmentView));
+                }
+                else if (selectedTag == "Drugs")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyDrugView));
+                }
+                else if (selectedTag == "Schedule")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyScheduleView));
+                }
+                else if (selectedTag == "Shifts")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyShiftView));
+                }
+                else if (selectedTag == "Departments")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyDepartmentView));
+                }
+                else if (selectedTag == "Rooms")
+                {
+                    ModifyPageFrame.Navigate(typeof(ModifyRoomView));
+                }
+            }
+        }
+    }
+}

--- a/project/Gui/ModifyViews/ModifyRoomView.xaml
+++ b/project/Gui/ModifyViews/ModifyRoomView.xaml
@@ -10,20 +10,22 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Rooms" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Rooms" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
 
-            <controls:DataGrid ItemsSource="{Binding Rooms}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Room ID" Binding="{Binding RoomID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Capacity" Binding="{Binding Capacity, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Equipment ID" Binding="{Binding EquipmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Rooms}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Room ID" Binding="{Binding RoomID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Capacity" Binding="{Binding Capacity, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Department ID" Binding="{Binding DepartmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Equipment ID" Binding="{Binding EquipmentID, UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyScheduleView.xaml
+++ b/project/Gui/ModifyViews/ModifyScheduleView.xaml
@@ -10,19 +10,21 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Schedules" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Schedules" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center"/>
 
-            <controls:DataGrid ItemsSource="{Binding Schedules}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Schedule ID" Binding="{Binding ScheduleID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Doctor ID" Binding="{Binding DoctorID,  UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                    <controls:DataGridTextColumn Header="Shift ID" Binding="{Binding ShiftID,  UpdateSourceTrigger=PropertyChanged}" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Schedules}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Schedule ID" Binding="{Binding ScheduleID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Doctor ID" Binding="{Binding DoctorID,  UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                        <controls:DataGridTextColumn Header="Shift ID" Binding="{Binding ShiftID,  UpdateSourceTrigger=PropertyChanged}" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Gui/ModifyViews/ModifyShiftView.xaml
+++ b/project/Gui/ModifyViews/ModifyShiftView.xaml
@@ -10,20 +10,22 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <StackPanel Margin="20">
-            <TextBlock Text="Modify Shift" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
+        <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Margin="20">
+                <TextBlock Text="Modify Shift" FontSize="20" FontWeight="Bold" Margin="0,0,0,10" HorizontalAlignment="Center" />
 
-            <controls:DataGrid ItemsSource="{Binding Shifts}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto">
-                <controls:DataGrid.Columns>
-                    <controls:DataGridTextColumn Header="Shift ID" Binding="{Binding ShiftID}" Width="*" IsReadOnly="True"/>
-                    <controls:DataGridTextColumn Header="Date" Binding="{Binding Path=Date, Converter={StaticResource DateOnlyToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
-                    <controls:DataGridTextColumn Header="Start Time" Binding="{Binding Path=StartTime, Converter={StaticResource TimeSpanToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
-                    <controls:DataGridTextColumn Header="End Time" Binding="{Binding Path=EndTime, Converter={StaticResource TimeSpanToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
-                </controls:DataGrid.Columns>
-            </controls:DataGrid>
+                <controls:DataGrid ItemsSource="{Binding Shifts}" AutoGenerateColumns="False" IsReadOnly="False" HorizontalAlignment="Stretch" Width="Auto" Height="400">
+                    <controls:DataGrid.Columns>
+                        <controls:DataGridTextColumn Header="Shift ID" Binding="{Binding ShiftID}" Width="*" IsReadOnly="True"/>
+                        <controls:DataGridTextColumn Header="Date" Binding="{Binding Path=Date, Converter={StaticResource DateOnlyToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
+                        <controls:DataGridTextColumn Header="Start Time" Binding="{Binding Path=StartTime, Converter={StaticResource TimeSpanToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
+                        <controls:DataGridTextColumn Header="End Time" Binding="{Binding Path=EndTime, Converter={StaticResource TimeSpanToStringConverter},UpdateSourceTrigger=PropertyChanged}" IsReadOnly="False" Width="*"/>
+                    </controls:DataGrid.Columns>
+                </controls:DataGrid>
 
-            <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
-            <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
-        </StackPanel>
+                <Button Content="Save Changes" Command="{Binding SaveChangesCommand}" HorizontalAlignment="Center" Margin="10"/>
+                <TextBlock Text="{Binding ErrorMessage}" Foreground="Red" HorizontalAlignment="Center"/>
+            </StackPanel>
+        </ScrollViewer>
     </Grid>
 </Page>

--- a/project/Project.csproj
+++ b/project/Project.csproj
@@ -28,6 +28,7 @@
     <None Remove="Gui\ModifyViews\ModifyDepartmentView.xaml" />
     <None Remove="Gui\ModifyViews\ModifyDrugView.xaml" />
     <None Remove="Gui\ModifyViews\ModifyEquipmentView.xaml" />
+    <None Remove="Gui\ModifyViews\ModifyPage.xaml" />
     <None Remove="Gui\ModifyViews\ModifyRoomView.xaml" />
     <None Remove="Gui\ModifyViews\ModifyScheduleView.xaml" />
     <None Remove="Gui\ModifyViews\ModifyShiftView.xaml" />
@@ -63,6 +64,11 @@
     <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.7.250310001" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="9.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Update="Gui\ModifyViews\ModifyPage.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <Page Update="Gui\AddPage.xaml">


### PR DESCRIPTION
#### PR Classification
This pull request introduces a new feature by restructuring the navigation and layout of the modification views in the application.

#### PR Summary
The changes enhance the user interface by implementing a new navigation page and updating existing views to improve scrolling and layout consistency. 
- `AdminMainPage.xaml.cs`: Updated navigation from `ModifyRoomView` to `ModifyPage`.
- `Modify*.xaml` files: Replaced `StackPanel` with `ScrollViewer` and set `DataGrid` height to `400`.
- `ModifyPage.xaml` and `ModifyPage.xaml.cs`: Added as a new navigation hub for various modification views.
- `Project.csproj`: Updated to include `ModifyPage.xaml` and remove references to `ModifyDoctorView.xaml`.
